### PR TITLE
Commenting out clinical trials from drivers

### DIFF
--- a/eLife-elem-citation-driver-final.sch
+++ b/eLife-elem-citation-driver-final.sch
@@ -48,8 +48,8 @@
 <!--     <element-citation publication-type="patent"> Tests          -->
   <include href="element-citation-patent.sch"/>  
   
-  <!--     <element-citation publication-type="clinicaltrial"> Tests     -->
-  <include href="element-citation-clinicaltrial.sch"/>  
+  <!--     <element-citation publication-type="clinicaltrial"> Tests - excluded due to changes in reference guidelines  -->
+  <!-- <include href="element-citation-clinicaltrial.sch"/>  -->
   
   <!--     <element-citation publication-type="software"> Tests          -->
   <include href="element-citation-software.sch"/>  

--- a/eLife-elem-citation-driver-pre-edit.sch
+++ b/eLife-elem-citation-driver-pre-edit.sch
@@ -56,8 +56,8 @@
   <!--     <element-citation publication-type="patent"> Tests          -->
   <include href="element-citation-patent.sch"/>  
   
-  <!--     <element-citation publication-type="clinicaltrial"> Tests          -->
-  <include href="element-citation-clinicaltrial.sch"/>  
+  <!--     <element-citation publication-type="clinicaltrial"> Tests - excluded due to changes in reference guidelines  -->
+  <!-- <include href="element-citation-clinicaltrial.sch"/>  --> 
   
   <!--     <element-citation publication-type="software"> Tests          -->
   <include href="element-citation-software.sch"/>  


### PR DESCRIPTION
This is to remove Clinical trials as an eLife reference type following a change in guidelines.