### PR TITLE
Replace '<xsl:value-of/>' with '<value-of/>' to fix diagnostics

### DIFF
--- a/eLife-elem-citation-driver-final.sch
+++ b/eLife-elem-citation-driver-final.sch
@@ -22,7 +22,6 @@
 
 <schema  id="Driver-Schematron-element-citation"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    queryBinding="xslt2">
     

--- a/eLife-elem-citation-driver-pre-edit.sch
+++ b/eLife-elem-citation-driver-pre-edit.sch
@@ -22,7 +22,6 @@
 
 <schema  id="Driver-Schematron-element-citation"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    queryBinding="xslt2">
     

--- a/element-citation-book-pre-edit.sch
+++ b/element-citation-book-pre-edit.sch
@@ -51,32 +51,32 @@
       role="warning" 
       id="warning-elem-cit-book-12">[warning-elem-cit-book-12]
       There should be a &lt;publisher-loc> element within a &lt;element-citation> of type 'book'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not have one &lt;publisher-loc> element.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not have one &lt;publisher-loc> element.</assert>
     
     <report test="chapter-title and not(person-group[@person-group-type='editor'])"
       role="warning" 
       id="warning-elem-cit-book-28">[warning-elem-cit-book-28]
       If &lt;chapter-title> is present, there should be a &lt;person-group> element of type 'editor' present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;chapter-title> but no &lt;person-group> of type 'editor'.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;chapter-title> but no &lt;person-group> of type 'editor'.</report>
     
     <report test="chapter-title and not(lpage) and not(fpage)"
       role="warning" 
       id="warning-elem-cit-book-36-3">[warning-elem-cit-book-36-3]
       If &lt;chapter-title> is present, &lt;fpage> and &lt;lpage> should also be present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' is missing &lt;fpage>, &lt;lpage>, or both.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' is missing &lt;fpage>, &lt;lpage>, or both.</report>
     
     <report test="fpage and not(lpage)"
       role="warning" 
       id="warning-elem-cit-book-36-4">[warning-elem-cit-book-36-4]
       If &lt;fpage> is present, &lt;lpage> should also be present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not have an &lt;lpage> element.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not have an &lt;lpage> element.</report>
     
    <!-- <report test="matches(fpage,'\D') or matches(lpage, '\D')"
       role="warning" 
       id="warning-elem-cit-book-36-5">[warning-elem-cit-book-36-5]
       The content of both &lt;fpage> and &lt;lpage> should be all numeric.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      &lt;fpage>: <xsl:value-of select="fpage"/> and &lt;lpage>: <xsl:value-of select="lpage"/>.</report>-->
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      &lt;fpage>: <value-of select="fpage"/> and &lt;lpage>: <value-of select="lpage"/>.</report>-->
 
   </rule>
 

--- a/element-citation-book-pre-edit.sch
+++ b/element-citation-book-pre-edit.sch
@@ -39,8 +39,7 @@
 
 <pattern
    id="element-citation-book-pre-edit-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="book" Pre-edit Tests</title>
 

--- a/element-citation-book.sch
+++ b/element-citation-book.sch
@@ -96,8 +96,8 @@
       role="error" 
       id="err-elem-cit-book-2-2">[err-elem-cit-book-2-2]
       The only values allowed for @person-group-type in book references are "author" and "editor".
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> type of 
-      '<xsl:value-of select="person-group/@person-group-type"/>'.</assert> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> type of 
+      '<value-of select="person-group/@person-group-type"/>'.</assert> 
     
     <assert test="count(person-group)=1 or (count(person-group/@person-group-type='author')+
       count(person-group/@person-group-type='editor')=2)"
@@ -105,36 +105,36 @@
       id="err-elem-cit-book-2-3">[err-elem-cit-book-2-3]
       In a book reference, there should be a single person-group element (either author or editor) or
       one person-group with @person-group-type="author" and one person-group with @person-group-type=editor.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="count(source)=1"
       role="error" 
       id="err-elem-cit-book-10-1">[err-elem-book-book-10-1]
       Each  &lt;element-citation> of type 'book' must contain one and
       only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(source)=1 and (source/string-length() + sum(descendant::source/*/string-length()) ge 2)"
       role="error" 
       id="err-elem-cit-book-10-2-1">[err-elem-cit-book-10-2-1]
       A  &lt;source> element within a &lt;element-citation> of type 'book' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(source)=1 and count(source/*)=count(source/(italic | sub | sup))"
       role="error" 
       id="err-elem-cit-book-10-2-2">[err-elem-cit-book-10-2-2]
       A  &lt;source> element within a &lt;element-citation> of type 'book' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
     
     <assert test="count(publisher-name)=1"
       role="error" 
       id="err-elem-cit-book-13-1">[err-elem-cit-book-13-1]
       One and only one &lt;publisher-name> is required in a book reference.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(publisher-name)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(publisher-name)"/>
       &lt;publisher-name> elements.</assert>
     
     <report test="some $p in document($publisher-locations)/locations/location/text()
@@ -142,34 +142,34 @@
       role="warning" 
       id="warning-elem-cit-book-13-3">[warning-elem-cit-book-13-3]
       The content of &lt;publisher-name> may not end with a publisher location. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains the string <xsl:value-of select="publisher-name"/>,
+      Reference '<value-of select="ancestor::ref/@id"/>' contains the string <value-of select="publisher-name"/>,
       which ends with a publisher location.</report>
     
     <report test="(lpage or fpage) and not(chapter-title)"
       role="error" 
       id="err-elem-cit-book-16">[err-elem-cit-book-16]
       In a book reference, &lt;lpage> and &lt;fpage> are allowed only if &lt;chapter-title> is present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> or &lt;fpage> but no &lt;chapter-title>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> or &lt;fpage> but no &lt;chapter-title>.</report>
     
     <report test="(lpage and fpage) and (fpage ge lpage[1])"
       role="error" 
       id="err-elem-cit-book-36">[err-elem-cit-book-36-1]
       If both &lt;lpage> and &lt;fpage> are present, the value of &lt;fpage> must be less than the value of &lt;lpage>. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> <xsl:value-of select="lpage"/>, which is 
-      less than or equal to &lt;fpage> <xsl:value-of select="fpage"/>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> <value-of select="lpage"/>, which is 
+      less than or equal to &lt;fpage> <value-of select="fpage"/>.</report>
     
     <report test="lpage and not (fpage)"
       role="error" 
       id="err-elem-cit-book-36-2">[err-elem-cit-book-36-2]
       If &lt;lpage> is present, &lt;fpage> must also be present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> but not &lt;fpage>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> but not &lt;fpage>.</report>
     
     <report test="count(lpage) > 1 or count(fpage) > 1"
       role="error" 
       id="err-elem-cit-book-36-6">[err-elem-cit-book-36-6]
       At most one &lt;lpage> and one &lt;fpage> are allowed. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(lpage)"/> &lt;lpage> 
-      elements and <xsl:value-of select="count(fpage)"/> &lt;fpage> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(lpage)"/> &lt;lpage> 
+      elements and <value-of select="count(fpage)"/> &lt;fpage> elements.</report>
     
     <assert test="count(*) = count(person-group| year| source| chapter-title| publisher-loc|publisher-name|volume| 
       edition| fpage| lpage| pub-id)"
@@ -178,7 +178,7 @@
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="book" are:
       &lt;person-group>, &lt;year>, &lt;source>, &lt;chapter-title>, &lt;publisher-loc>, &lt;publisher-name>, 
       &lt;volume>, &lt;edition>, &lt;fpage>, &lt;lpage>, and &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -187,7 +187,7 @@
       role="error" 
       id="err-elem-cit-book-2-1">[err-elem-cit-book-2-1]
       Each &lt;person-group> must have a @person-group-type attribute.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
       element with no @person-group-type attribute.</assert>
   </rule>
   
@@ -197,20 +197,20 @@
       role="error" 
       id="err-elem-cit-book-22">[err-elem-cit-book-22]
       If there is a &lt;chapter-title> element there must be one and only one &lt;person-group person-group-type="author">.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
       
     <assert test="count(../person-group[@person-group-type='editor']) le 1"
       role="error" 
       id="err-elem-cit-book-28-1">[err-elem-cit-book-28-1]
       If there is a &lt;chapter-title> element there may be a maximum of one &lt;person-group person-group-type="editor">.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
     <assert test="count(*) = count(sub|sup|italic)"
       role="error" 
       id="err-elem-cit-book-31">[err-elem-cit-book-31]
       A &lt;chapter-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
   
@@ -220,7 +220,7 @@
       role="error" 
       id="err-elem-cit-book-13-2">[err-elem-cit-book-13-2]
       No elements are allowed inside &lt;publisher-name>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;publisher-name> element.</assert>
     
   </rule>
@@ -231,7 +231,7 @@
       role="error" 
       id="err-elem-cit-book-15">[err-elem-cit-book-15]
       No elements are allowed inside &lt;edition>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;edition> element.</assert>
     
   </rule>
@@ -242,8 +242,8 @@
       role="error" 
       id="err-elem-cit-book-18">[err-elem-cit-book-18]
       If &lt;pub-id pub-id-type="pmid"> is present, the content must be all numeric. The content of 
-      &lt;pub-id pub-id-type="pmid"> in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is <xsl:value-of select="."/>.</report>
+      &lt;pub-id pub-id-type="pmid"> in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is <value-of select="."/>.</report>
     
   </rule>
   
@@ -253,8 +253,8 @@
       role="error" 
       id="err-elem-cit-book-17">[err-elem-cit-book-17]
       Each &lt;pub-id>, if present in a book reference, must have a @pub-id-type of one of these values: doi, pmid, isbn. 
-      The pub-id-type attribute on &lt;pub-id> in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is <xsl:value-of select="@pub-id-type"/>.</assert>
+      The pub-id-type attribute on &lt;pub-id> in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is <value-of select="@pub-id-type"/>.</assert>
     
   </rule>
 

--- a/element-citation-book.sch
+++ b/element-citation-book.sch
@@ -84,8 +84,7 @@
 
 <pattern
    id="element-citation-book-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="book" Tests</title>
              

--- a/element-citation-clinicaltrial.sch
+++ b/element-citation-clinicaltrial.sch
@@ -60,39 +60,39 @@
       id="err-elem-cit-clinicaltrial-2-1">[err-elem-cit-clinicaltrial-2-1]
       Each  &lt;element-citation> of type 'clinicaltrial' must contain one and
       only one &lt;person-group> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="person-group[@person-group-type=('author', 'collaborator', 'sponsor')]"
               role="error" 
               id="err-elem-cit-clinicaltrial-2-2">[err-elem-cit-clinicaltrial-2-2]
 Each  &lt;element-citation> of type 'clinicaltrial' must contain one &lt;person-group> 
 with the attribute person-group-type set to 'author', 'collaborator', or 'sponsor'. Reference 
-'<xsl:value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
-'<xsl:value-of select="person-group/@person-group-type"/>'.</assert> 
+'<value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
+'<value-of select="person-group/@person-group-type"/>'.</assert> 
 
       <assert test="count(article-title)=1"
         role="error" 
         id="err-elem-cit-clinicaltrial-8-1">[err-elem-cit-clinicaltrial-8-1]
         Each  &lt;element-citation> of type 'clinicaltrial' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(ext-link)=1"
       role="error" 
       id="err-elem-cit-clinicaltrial-10-1">[err-elem-cit-clinicaltrial-10-1]
       Each  &lt;element-citation> of type 'clinicaltrial' must contain one and
       only one &lt;ext-link> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(ext-link)"/> &lt;ext-link> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(ext-link)"/> &lt;ext-link> elements.</assert>
     
     <assert test="count(*) = count(person-group| year| article-title| source| ext-link)"
       role="error" 
       id="err-elem-cit-clinicaltrial-11">[err-elem-cit-clinicaltrial-11]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="clinicaltrial" are:
         &lt;person-group>, &lt;year>, &lt;article-title>, &lt;source>, and &lt;ext-link>
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -103,7 +103,7 @@ with the attribute person-group-type set to 'author', 'collaborator', or 'sponso
       id="err-elem-cit-clinicaltrial-8-2">[err-elem-cit-clinicaltrial-8-2]
       An &lt;article-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
   
@@ -112,22 +112,22 @@ with the attribute person-group-type set to 'author', 'collaborator', or 'sponso
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-clinicaltrial-10-2">[err-elem-cit-clinicaltrial-10-2]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-clinicaltrial-10-3">[err-elem-cit-clinicaltrial-10-3]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-clinicaltrial-10-4">[err-elem-cit-clinicaltrial-10-4]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
 

--- a/element-citation-clinicaltrial.sch
+++ b/element-citation-clinicaltrial.sch
@@ -48,8 +48,7 @@
 
 <pattern
    id="element-citation-clinicaltrial-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="clinicaltrial" Tests</title>
              

--- a/element-citation-confproc.sch
+++ b/element-citation-confproc.sch
@@ -89,66 +89,66 @@
       role="error" 
       id="err-elem-cit-confproc-2-1">[err-elem-cit-confproc-2-1]
       One and only one person-group element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="count(article-title)=1"
       role="error" 
       id="err-elem-cit-confproc-8-1">[err-elem-cit-confproc-8-1]
       Each  &lt;element-citation> of type 'confproc' must contain one and
       only one &lt;article-title> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(source) le 1"
       role="error" 
       id="err-elem-cit-confproc-9-1">[err-elem-confproc-confproc-9-1]
       Each  &lt;element-citation> of type 'confproc' may contain one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(conf-name)=1"
       role="error" 
       id="err-elem-cit-confproc-10-1">[err-elem-cit-confproc-10-1]
       &lt;conf-name> is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(conf-name)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(conf-name)"/>
       &lt;conf-name> elements.</assert>
     
     <report test="(fpage and elocation-id) or (lpage and elocation-id)"
       role="error" 
       id="err-elem-cit-confproc-12-1">[err-elem-cit-confproc-12-1]
       The citation may contain &lt;fpage> and &lt;lpage>, only &lt;fpage>, or only &lt;elocation-id> elements, but not a mixture.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage)"/>
-      &lt;fpage> elements,  <xsl:value-of select="count(lpage)"/> &lt;lpage> elements, and 
-      <xsl:value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage)"/>
+      &lt;fpage> elements,  <value-of select="count(lpage)"/> &lt;lpage> elements, and 
+      <value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
     
     <report test="count(fpage) gt 1 or count(lpage) gt 1 or count(elocation-id) gt 1"
       role="error" 
       id="err-elem-cit-confproc-12-2">[err-elem-cit-confproc-12-2]
       The citation may contain no more than one of any of &lt;fpage>, &lt;lpage>, and &lt;elocation-id> elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage)"/>
-      &lt;fpage> elements,  <xsl:value-of select="count(lpage)"/> &lt;lpage> elements, and 
-      <xsl:value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage)"/>
+      &lt;fpage> elements,  <value-of select="count(lpage)"/> &lt;lpage> elements, and 
+      <value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
     
     <report test="(lpage and fpage) and (fpage ge lpage)"
       role="error" 
       id="err-elem-cit-confproc-12-3">[err-elem-cit-confproc-12-3]
       If both &lt;lpage> and &lt;fpage> are present, the value of &lt;fpage> must be less than the value of &lt;lpage>. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> <xsl:value-of select="lpage"/>, which is 
-      less than or equal to &lt;fpage> <xsl:value-of select="fpage"/>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> <value-of select="lpage"/>, which is 
+      less than or equal to &lt;fpage> <value-of select="fpage"/>.</report>
     
     <assert test="count(fpage/*)=0 and count(lpage/*)=0"
       role="error" 
       id="err-elem-cit-confproc-12-4">[err-elem-cit-confproc-12-4]
       The content of the &lt;fpage> and &lt;lpage> elements can contain any alpha numeric value but no child elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage/*)"/> child elements in
-      &lt;fpage> and  <xsl:value-of select="count(lpage/*)"/> child elements in &lt;lpage>.</assert>     
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage/*)"/> child elements in
+      &lt;fpage> and  <value-of select="count(lpage/*)"/> child elements in &lt;lpage>.</assert>     
     
     <assert test="count(pub-id) le 1"
       role="error" 
       id="err-elem-cit-confproc-16-1">[err-elem-cit-confproc-16-1]
       A maximum of one &lt;pub-id> element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/>
       &lt;pub-id> elements.</assert>
     
     <assert test="count(*) = count(person-group | article-title | year| source | conf-loc | conf-name | lpage | 
@@ -158,7 +158,7 @@
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="confproc" are:
       &lt;person-group>, &lt;year>, &lt;article-title>, &lt;source>, &lt;conf-loc>, &lt;conf-name>, 
       &lt;fpage>, &lt;lpage>, &lt;elocation-id>, &lt;ext-link>, and &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -167,8 +167,8 @@
       role="error" 
       id="err-elem-cit-confproc-2-2">[err-elem-cit-confproc-2-2]
       Each &lt;person-group> must have a @person-group-type attribute of type 'author'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
-      element with @person-group-type attribute '<xsl:value-of select="@person-group-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
+      element with @person-group-type attribute '<value-of select="@person-group-type"/>'.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='confproc']/source" id="elem-citation-confproc-source">
@@ -177,7 +177,7 @@
     id="err-elem-cit-confproc-9-2-1">[err-elem-cit-confproc-9-2-1]
     A  &lt;source> element within a &lt;element-citation> of type 'confproc' must contain 
     at least two characters.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
   
   <assert test="count(*)=count(italic | sub | sup)"
     role="error" 
@@ -185,7 +185,7 @@
     A  &lt;source> element within a &lt;element-citation> of type 'confproc' may only contain the child 
     elements&lt;italic>, &lt;sub>, and &lt;sup>. 
     No other elements are allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
     
   </rule>
   
@@ -196,7 +196,7 @@
       id="err-elem-cit-confproc-8-2">[err-elem-cit-confproc-8-2]
       An &lt;article-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
   
@@ -206,7 +206,7 @@
       role="error" 
       id="err-elem-cit-confproc-10-2">[err-elem-cit-confproc-10-2]
       No elements are allowed inside &lt;conf-name>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;conf-name> element.</assert>
     
   </rule>
@@ -217,7 +217,7 @@
       role="error" 
       id="err-elem-cit-confproc-11-2">[err-elem-cit-confproc-11-2]
       No elements are allowed inside &lt;conf-loc>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;conf-loc> element.</assert>
     
   </rule>
@@ -229,8 +229,8 @@
       id="err-elem-cit-confproc-12-5">[err-elem-cit-confproc-12-5]
       If the content of &lt;fpage> begins with a letter, then the content of &lt;lpage> must begin with 
       the same letter. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;fpage>='<xsl:value-of select="."/>'
-      and &lt;lpage>='<xsl:value-of select="../lpage"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;fpage>='<value-of select="."/>'
+      and &lt;lpage>='<value-of select="../lpage"/>'.</assert>
     
   </rule>
   
@@ -240,8 +240,8 @@
       role="error" 
       id="err-elem-cit-confproc-16-2">[err-elem-cit-confproc-16-2]
       The only allowed pub-id types are 'doi' or 'pmid'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a pub-id type of 
-      '<xsl:value-of select="@pub-id-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a pub-id type of 
+      '<value-of select="@pub-id-type"/>'.</assert>
     
   </rule>
   
@@ -250,22 +250,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-confproc-14-1">[err-elem-cit-confproc-14-1]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-confproc-14-2">[err-elem-cit-confproc-14-2]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-confproc-14-3">[err-elem-cit-confproc-14-3]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
 

--- a/element-citation-confproc.sch
+++ b/element-citation-confproc.sch
@@ -78,8 +78,7 @@
 
 <pattern
    id="element-citation-confproc-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="confproc" Tests</title>
              

--- a/element-citation-data-pre-edit.sch
+++ b/element-citation-data-pre-edit.sch
@@ -35,8 +35,7 @@
 
 <pattern
    id="element-citation-data-pre-edit-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="data" Pre-edit Tests</title>
         

--- a/element-citation-data-pre-edit.sch
+++ b/element-citation-data-pre-edit.sch
@@ -46,7 +46,7 @@
       role="warning" 
       id="warning-elem-cit-data-2-1">[warning-elem-cit-data-2-1]
       There should be at least one &lt;person-group> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has none.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has none.</assert>
     
     <assert test="source"
       role="warning" 
@@ -60,8 +60,8 @@
     role="warning" 
     id="warning-elem-cit-data-2-2">[warning-elem-cit-data-2-2]
     The only valid @person-group-type values are author,compiler, curator.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> element with type
-    '<xsl:value-of select="@person-group-type"/>'.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> element with type
+    '<value-of select="@person-group-type"/>'.</assert>
   </rule>
 </pattern>
 

--- a/element-citation-data.sch
+++ b/element-citation-data.sch
@@ -80,68 +80,68 @@
       id="err-elem-cit-data-3-1">[err-elem-cit-data-3-1]
       Only one person-group of each type (author, compiler, curator) is allowed. 
       Reference 
-      '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
-      'author', <xsl:value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
-      'compiler', <xsl:value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
-      'curator', and <xsl:value-of select="count(person-group[@person-group-type!='author' and @person-group-type!='compiler' and @person-group-type!='curator'])"/>
+      '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
+      'author', <value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
+      'compiler', <value-of select="count(person-group[@person-group-type='author'])"/>  &lt;person-group> elements of type of 
+      'curator', and <value-of select="count(person-group[@person-group-type!='author' and @person-group-type!='compiler' and @person-group-type!='curator'])"/>
       &lt;person-group> elements of some other type.</assert>
     
     <assert test="count(person-group) ge 1"
       role="error" 
       id="err-elem-cit-data-3-2">[err-elem-cit-data-3-2]
       Each  &lt;element-citation> of type 'data' must contain at least one &lt;person-group> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
 
       <assert test="count(data-title)=1"
         role="error" 
         id="err-elem-cit-data-10">[err-elem-cit-data-10]
         Each  &lt;element-citation> of type 'data' must contain one and only one &lt;data-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(data-title)"/> &lt;data-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(data-title)"/> &lt;data-title> elements.</assert>
     
     <assert test="count(source)=1"
       role="error" 
       id="err-elem-cit-data-11-2">[err-elem-cit-data-11-2]
       Each  &lt;element-citation> of type 'data' must contain one and only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(source)=1 and (source/string-length() + sum(descendant::source/*/string-length()) ge 2)"
       role="error" 
       id="err-elem-cit-data-11-3-1">[err-elem-cit-data-11-3-1]
       A &lt;source> element within a &lt;element-citation> of type 'data' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(source)=1 and count(source/*)=count(source/(italic | sub | sup))"
       role="error" 
       id="err-elem-cit-data-11-3-2">[err-elem-cit-data-11-3-2]
       A  &lt;source> element within a &lt;element-citation> of type 'data' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
     <assert test="pub-id or ext-link"
       role="error" 
       id="err-elem-cit-data-13-1">[err-elem-cit-data-13-1]
       There must be at least one pub-id OR an &lt;ext-link>. There may be more than one pub-id.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/> &lt;pub-id elements
-      and <xsl:value-of select="count(ext-link)"/>  &lt;ext-link> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/> &lt;pub-id elements
+      and <value-of select="count(ext-link)"/>  &lt;ext-link> elements.</assert>
     
     <assert test="count(pub-id) ge 1 or count(ext-link) ge 1"
       role="error" 
       id="err-elem-cit-data-17-1">[err-elem-cit-data-17-1]
       The &lt;ext-link> element is required if there is no &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/> &lt;pub-id> elements
-      and <xsl:value-of select="count(ext-link)"/>  &lt;ext-link> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/> &lt;pub-id> elements
+      and <value-of select="count(ext-link)"/>  &lt;ext-link> elements.</assert>
 
     <assert test="count(*) = count(person-group| data-title| source| year| pub-id| version| ext-link)"
       role="error" 
       id="err-elem-cit-data-18">[err-elem-cit-data-18]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="data" are:
       &lt;person-group>, &lt;data-title>, &lt;source>, &lt;year>, &lt;pub-id>, &lt;version>, and &lt;ext-link>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
 
@@ -151,8 +151,8 @@
       role="error" 
       id="err-elem-cit-data-14-2">[err-elem-cit-data-14-2]
       If the pub-id is of pub-id-type doi, it may not have an @xlink:href.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with type doi and an
-      @link-href with value '<xsl:value-of select="@link-href"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with type doi and an
+      @link-href with value '<value-of select="@link-href"/>'.</assert>
     
   </rule>
 
@@ -162,15 +162,15 @@
       role="error" 
       id="err-elem-cit-data-13-2">[err-elem-cit-data-13-2]
       Each pub-id element must have one of these types: accession, archive, ark, assigning-authority or doi. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
-      '<xsl:value-of select="@pub-id-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with types 
+      '<value-of select="@pub-id-type"/>'.</assert>
     
     <assert test="if (@pub-id-type ne 'doi') then @xlink:href else ()"
       role="error" 
       id="err-elem-cit-data-14-1">[err-elem-cit-data-14-1]
       If the pub-id is of any pub-id-type except doi, it must have an @xlink:href. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with type 
-      '<xsl:value-of select="@pub-id-type"/>' but no @xlink-href.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;pub-id element with type 
+      '<value-of select="@pub-id-type"/>' but no @xlink-href.</assert>
     
   </rule>
   
@@ -179,22 +179,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-data-17-2">[err-elem-cit-data-17-2]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-data-17-3">[err-elem-cit-data-17-3]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-data-17-4">[err-elem-cit-data-17-4]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
   

--- a/element-citation-data.sch
+++ b/element-citation-data.sch
@@ -66,7 +66,6 @@
 <pattern
    id="element-citation-data-tests"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <title>element-citation publication-type="data" Tests</title>

--- a/element-citation-general-pre-edit.sch
+++ b/element-citation-general-pre-edit.sch
@@ -32,8 +32,7 @@
 
 <pattern
    id="element-citation-general-pre-edit-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation General Pre-edit Tests</title>
         

--- a/element-citation-general-pre-edit.sch
+++ b/element-citation-general-pre-edit.sch
@@ -43,7 +43,7 @@
       role="warning" 
       id="warn-elem-cit-gen-name-2">[warning-elem-cit-gen-name-2]
       Each &lt;name> element in a reference must contain a &lt;given-names> element. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>    
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.</report>    
 
   </rule>
   
@@ -55,8 +55,8 @@
       role="warning" 
       id="warn-elem-cit-gen-date-1-2">[warn-elem-cit-gen-date-1-2]
       The numeric value of the first 4 digits of the &lt;year> element should be between 1900 and the current year + 5 years (inclusive).
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="."/>'.
     </assert>    
     
   </rule>

--- a/element-citation-general.sch
+++ b/element-citation-general.sch
@@ -61,8 +61,7 @@
 
 <pattern 
    id="element-citation-general-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>General Tests for 'element-citation'</title>
   

--- a/element-citation-general.sch
+++ b/element-citation-general.sch
@@ -74,19 +74,19 @@
                role="error" 
                id="err-elem-cit-gen-name-2">[err-elem-cit-gen-name-2]
 Each &lt;name> element in a reference must contain a &lt;surname> element. 
-Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
+Reference '<value-of select="ancestor::ref/@id"/>' does not.</report>
   
   <report test="descendant::etal"
     role="error" 
     id="err-elem-cit-gen-name-5">[err-elem-cit-gen-name-5]
     The &lt;etal> element in a reference is not allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains it.</report>
+    Reference '<value-of select="ancestor::ref/@id"/>' contains it.</report>
   
   <report test="count(year)>1 "
     role="error" 
     id="err-elem-cit-gen-date-1-9">[err-elem-cit-gen-date-1-9]
     There may be at most one &lt;year> element.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(year)"/>
+    Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(year)"/>
     &lt;year> elements.
   </report>
 
@@ -99,7 +99,7 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-name-3-1">[err-elem-cit-gen-name-3-1]
       Each &lt;person-group> element in a reference must contain at least one
       &lt;name> or, if allowed, &lt;collab> element. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.</report>
     
   </rule>
   
@@ -110,7 +110,7 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-name-3-2">[err-elem-cit-gen-name-3-2]
       A &lt;collab> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains addiitonal elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' contains addiitonal elements.</assert>
     
   </rule>
 
@@ -121,8 +121,8 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-name-4">[err-elem-cit-gen-name-4]
       The &lt;suffix> element in a reference may only contain one of the specified values
       Jnr, Snr, I, II, III, VI, V, VI, VII, VIII, IX, X.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement
-      as it contains the value '<xsl:value-of select="suffix"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement
+      as it contains the value '<value-of select="suffix"/>'.</assert>
     
   </rule>
   
@@ -134,23 +134,23 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       role="error" 
       id="err-elem-cit-gen-date-1-1">[err-elem-cit-gen-date-1-1]
       The &lt;year> element in a reference must contain 4 digits, possibly followed by one (and only one) lower-case letter.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="."/>'.
     </assert>
     
     <assert test="(1700 le number($YYYY)) and (number($YYYY) le ($current-year + 5))"
       role="error" 
       id="err-elem-cit-gen-date-1-2">[err-elem-cit-gen-date-1-2]
       The numeric value of the first 4 digits of the &lt;year> element must be between 1700 and the current year + 5 years (inclusive).
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="."/>'.
     </assert>
     
     <assert test="./@iso-8601-date"
       role="error" 
       id="err-elem-cit-gen-date-1-3">[err-elem-cit-gen-date-1-3]
       All &lt;year> elements must have @iso-8601-date attributes.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.
     </assert>
     
     <assert test="not(./@iso-8601-date) or (1700 le number(substring(normalize-space(@iso-8601-date),1,4)) and number(substring(normalize-space(@iso-8601-date),1,4)) le ($current-year + 5))"
@@ -158,8 +158,8 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-date-1-4">[err-elem-cit-gen-date-1-4]
       The numeric value of the first 4 digits of the @iso-8601-date attribute on the &lt;year> element must be between 
       1700 and the current year + 5 years (inclusive).
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as the attribute contains the value 
-      '<xsl:value-of select="./@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the attribute contains the value 
+      '<value-of select="./@iso-8601-date"/>'.
     </assert>
     
     <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY"
@@ -167,9 +167,9 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-date-1-5">[err-elem-cit-gen-date-1-5]
       The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
       &lt;year> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-      the value '<xsl:value-of select="."/>' and the attribute contains the value 
-      '<xsl:value-of select="./@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+      the value '<value-of select="."/>' and the attribute contains the value 
+      '<value-of select="./@iso-8601-date"/>'.
     </assert>
     
     <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and 
@@ -182,7 +182,7 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-date-1-6">[err-elem-cit-gen-date-1-6]
       If the &lt;year> element contains the letter 'a' after the digits, there must be another reference with 
       the same first author surname (or collab) with a letter "b" after the year. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
     
     <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or
       (some $y in //element-citation/descendant::year 
@@ -195,7 +195,7 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       id="err-elem-cit-gen-date-1-7">[err-elem-cit-gen-date-1-7]
       If the &lt;year> element contains any letter other than 'a' after the digits, there must be another 
       reference with the same first author surname (or collab) with the preceding letter after the year. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
     
     <report test="some $x in (preceding::year)
       satisfies (((count(ancestor::element-citation/person-group[1]/*)=1 and 
@@ -235,9 +235,9 @@ Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</report>
       role="error" 
       id="err-elem-cit-gen-date-1-8">[err-elem-cit-gen-date-1-8]
       Letter suffixes must be unique for the combination of year and author information. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
-      contains the &lt;year> '<xsl:value-of select="."/>' for the author information
-      '<xsl:value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>', which occurs in at least one other reference.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
+      contains the &lt;year> '<value-of select="."/>' for the author information
+      '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>', which occurs in at least one other reference.</report>
     
   </rule>
   

--- a/element-citation-high.sch
+++ b/element-citation-high.sch
@@ -94,7 +94,7 @@
       id="err-elem-cit-high-1">[err-elem-cit-high-1]
       The only element that is allowed as a child of &lt;ref> is
       &lt;element-citation>. 
-      Reference '<xsl:value-of select="@id"/>' has other elements.
+      Reference '<value-of select="@id"/>' has other elements.
     </assert>
     
     <!-- else:
@@ -121,7 +121,7 @@
       by the first author’s surname, or by the value of the first &lt;collab> element. In the case of
       two authors, the sequence should be arranged by both authors' surnames, then date. For
       three or more authors, the sequence should be the first author's surname, then date.
-      Reference '<xsl:value-of select="@id"/>' appears to be in a different order.
+      Reference '<value-of select="@id"/>' appears to be in a different order.
     </assert>
  
     <assert test="@id"
@@ -135,8 +135,8 @@
       id="err-elem-cit-high-3-2">[err-elem-cit-high-3-2]
       Each &lt;ref> element must have an @id attribute that starts with 'bib' and ends with 
       a number. 
-      Reference '<xsl:value-of select="@id"/>' has the value 
-      '<xsl:value-of select="@id"/>', which is incorrect.
+      Reference '<value-of select="@id"/>' has the value 
+      '<value-of select="@id"/>', which is incorrect.
     </assert>
     
     <assert test="count(preceding-sibling::ref)=0 or number(substring(@id,4)) gt number(substring(preceding-sibling::ref[1]/@id,4))"
@@ -144,8 +144,8 @@
       id="err-elem-cit-high-3-3">[err-elem-cit-high-3-3]
       The sequence of ids in the &lt;ref> elements must increase monotonically
       (e.g. 1,2,3,4,5, . . . ,50,51,52,53, . . . etc).
-      Reference '<xsl:value-of select="@id"/>' has the value 
-      '<xsl:value-of select="@id"/>', which does not fit this pattern.
+      Reference '<value-of select="@id"/>' has the value 
+      '<value-of select="@id"/>', which does not fit this pattern.
     </assert>
     
     <let name="year-comma" value="', \d{4}\w?$'"/>
@@ -208,7 +208,7 @@
       )"
       role="error"
       id="err-elem-cit-high-4">
-      <xsl:value-of select="$name"/> and  <xsl:value-of select="$name2"/> 
+      <value-of select="$name"/> and  <value-of select="$name2"/> 
       [err-elem-cit-high-4]
       <!--     <let name="name" value="lower-case(if (local-name(element-citation/person-group[1]/*[1])='name')
       then (element-citation/person-group[1]/name[1]/surname)
@@ -227,9 +227,9 @@
       point to that reference must contain the content of only the first 
       of the &lt;surname>s, followed by the text "et al."
       All of these are followed by ', ' and the year, or by the year in parentheses.
-      There are <xsl:value-of select="count(//xref[@rid=current()/@id]/@rid)"/> &lt;xref> references 
-      with @rid = <xsl:value-of select="@id"/> to be checked. The first name should be 
-      '<xsl:value-of select="element-citation/person-group[1]/(name[1]/surname | collab[1])[1]"/>'.
+      There are <value-of select="count(//xref[@rid=current()/@id]/@rid)"/> &lt;xref> references 
+      with @rid = <value-of select="@id"/> to be checked. The first name should be 
+      '<value-of select="element-citation/person-group[1]/(name[1]/surname | collab[1])[1]"/>'.
     </assert>
     
       <!-- If there is more than one year (caught by a different test), use the first year to compare. -->
@@ -241,10 +241,10 @@
       All xrefs to &lt;ref>s, which contain &lt;element-citation>s, should contain, as the last part 
       of their content, the string ", " followed by the content of the year element in the 
       &lt;element-citation>, or the year in parentheses. 
-      There is an incorrect &lt;xref> with @rid <xsl:value-of select="@id"/>. It should contain the string 
-      ', <xsl:value-of select="element-citation/year"/>' or the string 
-      '(<xsl:value-of select="element-citation/year"/>)' but does not.
-      There are <xsl:value-of select="count(//xref[@rid=current()/@id]/@rid)"/> references to be checked.
+      There is an incorrect &lt;xref> with @rid <value-of select="@id"/>. It should contain the string 
+      ', <value-of select="element-citation/year"/>' or the string 
+      '(<value-of select="element-citation/year"/>)' but does not.
+      There are <value-of select="count(//xref[@rid=current()/@id]/@rid)"/> references to be checked.
     </assert>
     
   </rule>
@@ -257,7 +257,7 @@
       role="error" 
       id="err-xref-high-2-1">[err-xref-high-2-1]
       Citations in the text to references with the same author(s) in the same year must be arranged in the same 
-      order as the reference list. The xref with the value '<xsl:value-of select="."/>' is in the wrong order in the 
+      order as the reference list. The xref with the value '<value-of select="."/>' is in the wrong order in the 
       text. Check all the references to citations for the same authors to determine which need to be changed.
     </assert>
     
@@ -268,7 +268,7 @@
   <assert test="@publication-type" role="error" 
     id="err-elem-cit-high-6-1">[err-elem-cit-high-6-1]
     The element-citation element must have a publication-type attribute.
-    Reference '<xsl:value-of select="../@id"/>' does not.
+    Reference '<value-of select="../@id"/>' does not.
   </assert>
 
       <assert test="@publication-type = 'journal' or
@@ -287,8 +287,8 @@
         The publication-type attribute may only take the values 'journal', 'book', 'data', 
         'patent', 'software', 'preprint', 'web', 
         'periodical', 'report', 'confproc', or 'thesis'. 
-        Reference '<xsl:value-of select="../@id"/>' has the publication-type 
-        '<xsl:value-of select="@publication-type"/>'.</assert>
+        Reference '<value-of select="../@id"/>' has the publication-type 
+        '<value-of select="@publication-type"/>'.</assert>
 
   </rule>
 

--- a/element-citation-high.sch
+++ b/element-citation-high.sch
@@ -65,8 +65,7 @@
 
 <pattern 
    id="element-citation-high-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>High-level Tests for 'element-citation'</title>
   

--- a/element-citation-journal-pre-edit.sch
+++ b/element-citation-journal-pre-edit.sch
@@ -42,8 +42,7 @@
 
 <pattern
    id="element-citation-journal-pre-edit-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="journal" Pre-edit Tests</title>
 

--- a/element-citation-journal-pre-edit.sch
+++ b/element-citation-journal-pre-edit.sch
@@ -55,34 +55,34 @@
       id="warning-elem-cit-journal-5-2">[warning-elem-cit-journal-5-2]
       There should be either a &lt;volume> element within a &lt;element-citation> of type 'journal',
       or a &lt;comment> with content 'In press'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has neither.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has neither.</assert>
     
     <report test="fpage and not(lpage)"
       role="warning" 
       id="warning-elem-cit-journal-6-8">[warning-elem-cit-journal-6-8]
       If &lt;fpage> is present, &lt;lpage> should also be present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not have an &lt;lpage> element.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not have an &lt;lpage> element.</report>
     
     <report test="matches(fpage[1],'\D') or matches(lpage[1], '\D')"
       role="warning" 
       id="warning-elem-cit-journal-6-9">[warning-elem-cit-journal-6-9]
       The content of both &lt;fpage> and &lt;lpage> should be all numeric.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      &lt;fpage>: <xsl:value-of select="fpage"/> and &lt;lpage>: <xsl:value-of select="lpage"/>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      &lt;fpage>: <value-of select="fpage"/> and &lt;lpage>: <value-of select="lpage"/>.</report>
     
     <report test="comment/text()='In press'"
       role="warning" 
       id="warning-elem-cit-journal-6-10">[warning-elem-cit-journal-6-10]
       This citation has a &lt;comment> with content 'In press' in 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>'. Check for updates.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>'. Check for updates.</report>
     
     <assert test="pub-id/@pub-id-type='doi' or
       (normalize-space(document($journal-doi)/journals/journal[name=normalize-space(current()/source)]/year) > substring(normalize-space(year[1]),1,4))"
       role="warning" 
       id="warning-elem-cit-journal-9-2">[warning-elem-cit-journal-9-2]
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not have a pub-id with pub-id-type 'doi',
+      Reference '<value-of select="ancestor::ref/@id"/>' does not have a pub-id with pub-id-type 'doi',
       and the source is not on the list of journals that do not have DOIs. Check for the missing DOI for this reference:
-      &lt;source> '<xsl:value-of select="source"/>', &lt;year> <xsl:value-of select="year"/>.
+      &lt;source> '<value-of select="source"/>', &lt;year> <value-of select="year"/>.
     </assert>
 
   </rule>

--- a/element-citation-journal.sch
+++ b/element-citation-journal.sch
@@ -78,8 +78,7 @@
 
 <pattern
    id="element-citation-journal-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="journal" Tests</title>
              

--- a/element-citation-journal.sch
+++ b/element-citation-journal.sch
@@ -90,82 +90,82 @@
       id="err-elem-cit-journal-2-1">[err-elem-cit-journal-2-1]
       Each  &lt;element-citation> of type 'journal' must contain one and
       only one &lt;person-group> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="person-group[@person-group-type='author']"
       role="error" 
       id="err-elem-cit-journal-2-2">[err-elem-cit-journal-2-2]
       Each  &lt;element-citation> of type 'journal' must contain one &lt;person-group> 
       with the attribute person-group-type 'author'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
-      '<xsl:value-of select="person-group/@person-group-type"/>'.</assert> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
+      '<value-of select="person-group/@person-group-type"/>'.</assert> 
 
       <assert test="count(article-title)=1"
         role="error" 
         id="err-elem-cit-journal-3-1">[err-elem-cit-journal-3-1]
         Each  &lt;element-citation> of type 'journal' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(source)=1"
       role="error" 
       id="err-elem-cit-journal-4-1">[err-elem-cit-journal-4-1]
       Each  &lt;element-citation> of type 'journal' must contain one and
       only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(source)=1 and (source/string-length() + sum(descendant::source/*/string-length()) ge 2)"
       role="error" 
       id="err-elem-cit-journal-4-2-1">[err-elem-cit-journal-4-2-1]
       A  &lt;source> element within a &lt;element-citation> of type 'journal' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(source)=1 and count(source/*)=0"
       role="error" 
       id="err-elem-cit-journal-4-2-2">[err-elem-cit-journal-4-2-2]
       A  &lt;source> element within a &lt;element-citation> of type 'journal' may not contain child 
       elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
     <assert test="count(volume) le 1"
       role="error" 
       id="err-elem-cit-journal-5-1-3">[err-elem-cit-journal-5-1-3]
       There may be no more than one  &lt;volume> element within a &lt;element-citation> of type 'journal'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(volume)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(volume)"/>
       &lt;volume> elements.</assert>
     
     <assert test="(count(fpage) eq 1) or (count(elocation-id) eq 1) or (count(comment/text()='In press') eq 1)"
       role="warning" 
       id="warning-elem-cit-journal-6-1">[warning-elem-cit-journal-6-1]
       One of &lt;fpage>, &lt;elocation-id>, or &lt;comment>In press&lt;/comment> should be present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has missing page or elocation information.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has missing page or elocation information.</assert>
     
     <report test="lpage and not(fpage)"
       role="error" 
       id="err-elem-cit-journal-6-5-1">[err-elem-cit-journal-6-5-1]
       &lt;lpage> is only allowed if &lt;fpage> is present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> but no &lt;fpage>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> but no &lt;fpage>.</report>
     
     <report test="lpage and (number(fpage[1]) >= number(lpage[1]))"
       role="error" 
       id="err-elem-cit-journal-6-5-2">[err-elem-cit-journal-6-5-2]
       &lt;lpage> must be larger than &lt;fpage>, if present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has first page &lt;fpage> = '<xsl:value-of select="fpage"/>' 
-      but last page &lt;lpage> = '<xsl:value-of select="lpage"/>'.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has first page &lt;fpage> = '<value-of select="fpage"/>' 
+      but last page &lt;lpage> = '<value-of select="lpage"/>'.</report>
     
     <report test="count(fpage) gt 1 or count(lpage) gt 1 or count(elocation-id) gt 1 or count(comment) gt 1"
       role="error" 
       id="err-elem-cit-journal-6-7">[err-elem-cit-journal-6-7]
       The following elements may not occur more than once in an &lt;element-citation>: &lt;fpage>, &lt;lpage>, 
       &lt;elocation-id>, and &lt;comment>In press&lt;/comment>. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(fpage)"/> &lt;fpage>, <xsl:value-of select="count(lpage)"/> &lt;lpage>,
-      <xsl:value-of select="count(elocation-id)"/> &lt;elocation-id>, and 
-      <xsl:value-of select="count(comment)"/> &lt;comment> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(fpage)"/> &lt;fpage>, <value-of select="count(lpage)"/> &lt;lpage>,
+      <value-of select="count(elocation-id)"/> &lt;elocation-id>, and 
+      <value-of select="count(comment)"/> &lt;comment> elements.</report>
     
     <assert test="count(*) = count(person-group| year| article-title| source| volume| fpage| lpage| elocation-id| comment| pub-id)"
       role="error" 
@@ -173,7 +173,7 @@
       The only elements allowed as children of &lt;element-citation> with the publication-type="journal" are:
         &lt;person-group>, &lt;year>, &lt;article-title>, &lt;source>, &lt;volume>, &lt;fpage>, &lt;lpage>, 
         &lt;elocation-id>, &lt;comment>, and &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -184,7 +184,7 @@
       id="err-elem-cit-journal-3-2">[err-elem-cit-journal-3-2]
       An &lt;article-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
 
@@ -194,7 +194,7 @@
     id="err-elem-cit-journal-5-1-2">[err-elem-cit-journal-5-1-2]
     A  &lt;volume> element within a &lt;element-citation> of type 'journal' must contain 
     at least one character and may not contain child elements.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters and/or
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters and/or
     child elements.</assert>
   </rule>
   
@@ -204,14 +204,14 @@
       role="error" 
       id="err-elem-cit-journal-6-2">[err-elem-cit-journal-6-2]
       If &lt;fpage> is present, neither &lt;elocation-id> nor &lt;comment>In press&lt;/comment> may be present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;fpage> and one of those elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;fpage> and one of those elements.</assert>
     
     <assert test="matches(normalize-space(.),'^\d.*') or (substring(normalize-space(../lpage[1]),1,1) = substring(normalize-space(.),1,1)) or count(../lpage) eq 0"
       role="error" 
       id="err-elem-cit-journal-6-6">[err-elem-cit-journal-6-6]
       If the content of &lt;fpage> begins with a letter, then the content of  &lt;lpage> must begin with 
       the same letter. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.</assert>
     
   </rule>
   
@@ -221,7 +221,7 @@
       role="error" 
       id="err-elem-cit-journal-6-3">[err-elem-cit-journal-6-3]
       If &lt;elocation-id> is present, neither &lt;fpage> nor &lt;comment>In press&lt;/comment> may be present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;elocation-id> and one of those elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;elocation-id> and one of those elements.</assert>
     
   </rule>
   
@@ -231,13 +231,13 @@
       role="error" 
       id="err-elem-cit-journal-6-4">[err-elem-cit-journal-6-4]
       If &lt;comment>In press&lt;/comment> is present, neither &lt;fpage> nor &lt;elocation-id> may be present. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has one of those elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has one of those elements.</assert>
     
     <assert test="text() = 'In press'"
       role="error" 
       id="err-elem-cit-journal-13">[err-elem-cit-journal-13] 
       Comment elements with content other than 'In press' are not allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has such a &lt;comment> element.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has such a &lt;comment> element.</assert>
     
   </rule>
   
@@ -247,8 +247,8 @@
       role="error" 
       id="err-elem-cit-journal-10">[err-elem-cit-journal-10]
       If &lt;pub-id pub-id-type="pmid"> is present, the content must be all numeric.
-      The content of &lt;pub-id pub-id-type="pmid"> in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is <xsl:value-of select="."/>.</report>
+      The content of &lt;pub-id pub-id-type="pmid"> in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is <value-of select="."/>.</report>
     
   </rule>
   
@@ -258,8 +258,8 @@
       role="error" 
       id="err-elem-cit-journal-9-1">[err-elem-cit-journal-9-1]
       Each &lt;pub-id>, if present in a journal reference, must have a @pub-id-type of either "doi" or "pmid".
-      The pub-id-type attribute on &lt;pub-id> in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is <xsl:value-of select="@pub-id-type"/>.</assert>
+      The pub-id-type attribute on &lt;pub-id> in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is <value-of select="@pub-id-type"/>.</assert>
     
   </rule>
   

--- a/element-citation-patent.sch
+++ b/element-citation-patent.sch
@@ -67,8 +67,8 @@
       role="error" 
       id="err-elem-cit-patent-2-1">[err-elem-cit-patent-2-1]
       There must be one person-group with @person-group-type="inventor". 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has
-      <xsl:value-of select="count(person-group[@person-group-type='inventor'])"/> &lt;person-group> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has
+      <value-of select="count(person-group[@person-group-type='inventor'])"/> &lt;person-group> 
       elements of type 'inventor'.</assert>
     
     <assert test="every $type in person-group/@person-group-type
@@ -76,14 +76,14 @@
       role="error" 
       id="err-elem-cit-patent-2-3">[err-elem-cit-patent-2-3]
       The only allowed types of person-group elements are "assignee" and "inventor".
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;person-group> elements of other types.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;person-group> elements of other types.</assert>
     
     <assert test="count(person-group[@person-group-type='assignee']) le 1"
       role="error" 
       id="err-elem-cit-patent-2A">[err-elem-cit-patent-2A]
       There may be zero or one person-group elements with @person-group-type="assignee" 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group[@person-group-type='assignee'])"/> &lt;person-group> elements of type
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group[@person-group-type='assignee'])"/> &lt;person-group> elements of type
       'assignee'.</assert>
 
       <assert test="count(article-title)=1"
@@ -91,34 +91,34 @@
         id="err-elem-cit-patent-8-1">[err-elem-cit-patent-8-1]
         Each  &lt;element-citation> of type 'patent' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(source) le 1"
       role="error" 
       id="err-elem-cit-patent-9-1">[err-elem-cit-patent-9-1]
       Each  &lt;element-citation> of type 'patent' may contain zero or one &lt;source> elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="patent"
       role="error" 
       id="err-elem-cit-patent-10-1-1">[err-elem-cit-patent-10-1-1]
       The  &lt;patent> element is required. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has no &lt;patent> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;patent> elements.</assert>
     
     <assert test="ext-link"
       role="error" 
       id="err-elem-cit-patent-11-1">[err-elem-cit-patent-11-1]
       The &lt;ext-link> element is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has no &lt;ext-link> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has no &lt;ext-link> elements.</assert>
 
     <assert test="count(*) = count(person-group| article-title| source| year| patent| ext-link)"
       role="error" 
       id="err-elem-cit-patent-18">[err-elem-cit-patent-18]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="patent" are:
       &lt;person-group>, &lt;article-title>, &lt;source>, &lt;year>, &lt;patent>, and &lt;ext-link>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
 
@@ -127,22 +127,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-patent-11-2">[err-elem-cit-patent-11-2]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-patent-11-3">[err-elem-cit-patent-11-3]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-patent-11-4">[err-elem-cit-patent-11-4]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
   
@@ -152,7 +152,7 @@
     id="err-elem-cit-patent-8-2-1">[err-elem-cit-patent-8-2-1]
     A  &lt;article-title> element within a &lt;element-citation> of type 'patent' must contain 
     at least two characters.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
   
   <assert test="count(*)=count(italic | sub | sup)"
     role="error" 
@@ -160,7 +160,7 @@
     A  &lt;article-title> element within a &lt;element-citation> of type 'patent' may only contain the child 
     elements&lt;italic>, &lt;sub>, and &lt;sup>. 
     No other elements are allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='patent']/source" id="elem-citation-patent-source"> 
@@ -169,7 +169,7 @@
       id="err-elem-cit-patent-9-2-1">[err-elem-cit-patent-9-2-1]
       A  &lt;source> element within a &lt;element-citation> of type 'patent' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(*)=count(italic | sub | sup)"
       role="error" 
@@ -177,7 +177,7 @@
       A  &lt;source> element within a &lt;element-citation> of type 'patent' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
   </rule>
   
@@ -188,14 +188,14 @@
       role="error" 
       id="err-elem-cit-patent-10-1-2">[err-elem-cit-patent-10-1-2]
       The  &lt;patent> element may not have child elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements.</assert>
     
     <assert test="not(@country) or (@country = document($countries)/countries/country)"
       role="error" 
       id="err-elem-cit-patent-10-2">[err-elem-cit-patent-10-2]
       The country attribute on the &lt;patent> element is optional, but must have a value from the list if present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a patent/@country attribute with the value 
-      '<xsl:value-of select="@country"/>', which is not in the list.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a patent/@country attribute with the value 
+      '<value-of select="@country"/>', which is not in the list.</assert>
 
   </rule>
 </pattern>

--- a/element-citation-patent.sch
+++ b/element-citation-patent.sch
@@ -56,7 +56,6 @@
 <pattern
    id="element-citation-patent-tests"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <title>element-citation publication-type="patent" Tests</title>

--- a/element-citation-periodical.sch
+++ b/element-citation-periodical.sch
@@ -89,8 +89,7 @@
 
 <pattern
    id="element-citation-periodical-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="periodical" Tests</title>
              

--- a/element-citation-periodical.sch
+++ b/element-citation-periodical.sch
@@ -101,22 +101,22 @@
       id="err-elem-cit-periodical-2-1">[err-elem-cit-periodical-2-1]
       Each  &lt;element-citation> of type 'periodical' must contain one and
       only one &lt;person-group> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
       <assert test="person-group[@person-group-type='author']"
               role="error" 
               id="err-elem-cit-periodical-2-2">[err-elem-cit-periodical-2-2]
 Each  &lt;element-citation> of type 'periodical' must contain one &lt;person-group> 
 with the attribute person-group-type set to 'author'. Reference 
-'<xsl:value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
-'<xsl:value-of select="person-group/@person-group-type"/>'.</assert> 
+'<value-of select="ancestor::ref/@id"/>' has a  &lt;person-group> type of 
+'<value-of select="person-group/@person-group-type"/>'.</assert> 
     
     <assert test="count(string-date/year)=1"
       role="error" 
       id="err-elem-cit-periodical-7-1">[err-elem-cit-periodical-7-1]
       There must be one and only one &lt;year> element in a &lt;string-date> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(year)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(year)"/>
       &lt;year> elements in the &lt;string-date> element.</assert>
 
       <assert test="count(article-title)=1"
@@ -124,23 +124,23 @@ with the attribute person-group-type set to 'author'. Reference
         id="err-elem-cit-periodical-8-1">[err-elem-cit-periodical-8-1]
         Each  &lt;element-citation> of type 'periodical' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(source)=1"
       role="error" 
       id="err-elem-cit-periodical-9-1">[err-elem-cit-periodical-9-1]
       Each  &lt;element-citation> of type 'periodical' must contain one and
       only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(source)=1 and (source/string-length() + sum(descendant::source/*/string-length()) ge 2)"
       role="error" 
       id="err-elem-cit-periodical-9-2-1">[err-elem-cit-periodical-9-2-1]
       A  &lt;source> element within a &lt;element-citation> of type 'periodical' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(source)=1 and count(source/*)=count(source/(italic | sub | sup))"
       role="error" 
@@ -148,56 +148,56 @@ with the attribute person-group-type set to 'author'. Reference
       A  &lt;source> element within a &lt;element-citation> of type 'periodical' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
     <assert test="count(volume) le 1"
       role="error" 
       id="err-elem-cit-periodical-10-1-3">[err-elem-cit-periodical-10-1-3]
       There may be at most one  &lt;volume> element within a &lt;element-citation> of type 'periodical'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(volume)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(volume)"/>
       &lt;volume> elements.</assert>
     
     <report test="lpage and not(fpage)"
       role="error" 
       id="err-elem-cit-periodical-11-1">[err-elem-cit-periodical-11-1]
       If &lt;lpage> is present, &lt;fpage> must also be present.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage)"/>
-      &lt;fpage> elements,  <xsl:value-of select="count(lpage)"/> &lt;lpage> elements, and 
-      <xsl:value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage)"/>
+      &lt;fpage> elements,  <value-of select="count(lpage)"/> &lt;lpage> elements, and 
+      <value-of select="count(elocation-id)"/> &lt;elocation-id> elements.</report>
     
     <report test="count(fpage) gt 1 or count(lpage) gt 1"
       role="error" 
       id="err-elem-cit-periodical-11-2">[err-elem-cit-periodical-11-2]
       The citation may contain no more than one &lt;fpage> or &lt;lpage> elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage)"/>
-      &lt;fpage> elements and <xsl:value-of select="count(lpage)"/> &lt;lpage> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage)"/>
+      &lt;fpage> elements and <value-of select="count(lpage)"/> &lt;lpage> elements.</report>
     
     <report test="(lpage and fpage) and (fpage ge lpage)"
       role="error" 
       id="err-elem-cit-periodical-11-3">[err-elem-cit-periodical-11-3]
       If both &lt;lpage> and &lt;fpage> are present, the value of &lt;fpage> must be less than the value of &lt;lpage>. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;lpage> <xsl:value-of select="lpage"/>, which is 
-      less than or equal to &lt;fpage> <xsl:value-of select="fpage"/>.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;lpage> <value-of select="lpage"/>, which is 
+      less than or equal to &lt;fpage> <value-of select="fpage"/>.</report>
     
     <assert test="count(fpage/*)=0 and count(lpage/*)=0"
       role="error" 
       id="err-elem-cit-periodical-11-4">[err-elem-cit-periodical-11-4]
       The content of the &lt;fpage> and &lt;lpage> elements can contain any alpha numeric value but no child elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(fpage/*)"/> child elements in
-      &lt;fpage> and  <xsl:value-of select="count(lpage/*)"/> child elements in &lt;lpage>.</assert>     
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(fpage/*)"/> child elements in
+      &lt;fpage> and  <value-of select="count(lpage/*)"/> child elements in &lt;lpage>.</assert>     
     
     <assert test="count(*) = count(person-group | year | string-date | article-title | source | volume | fpage | lpage)"
       role="error" 
       id="err-elem-cit-periodical-13">[err-elem-cit-periodical-13]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="periodical" are:
         &lt;person-group>, &lt;year>, &lt;string-date>, &lt;article-title>, &lt;source>, &lt;volume>, &lt;fpage>, and &lt;lpage>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
     
     <assert test="count(string-date)=1"
       role="error" 
       id="err-elem-cit-periodical-14-1">[err-elem-cit-periodical-14-1]
       There must be one and only one &lt;string-date> element within a &lt;element-citation> of type 'periodical'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(string-date)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(string-date)"/>
       &lt;string-date> elements.</assert>
 
   </rule>
@@ -211,31 +211,31 @@ with the attribute person-group-type set to 'author'. Reference
       role="error" 
       id="err-elem-cit-periodical-7-2">[err-elem-cit-periodical-7-2]
       The &lt;year> element must have an @iso-8601-date attribute.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.
     </assert>
     
     <assert test="matches(normalize-space(@iso-8601-date),'(^\d{4}-\d{2}-\d{2})|(^\d{4}-\d{2})')"
       role="error" 
       id="err-elem-cit-periodical-7-3">[err-elem-cit-periodical-7-3]
       The @iso-8601-date value must include 4 digit year, 2 digit month, and (optionally) a 2 digit day.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="@iso-8601-date"/>'.
     </assert>
 
     <assert test="matches(normalize-space(.),'(^\d{4}[a-z]?)')"
       role="error" 
       id="err-elem-cit-periodical-7-4-1">[err-elem-cit-periodical-7-4-1]
       The &lt;year> element in a reference must contain 4 digits, possibly followed by one (but not more) lower-case letter.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="."/>'.
     </assert>
     
     <assert test="(1700 le number($YYYY)) and (number($YYYY) le $current-year)"
       role="error" 
       id="err-elem-cit-periodical-7-4-2">[err-elem-cit-periodical-7-4-2]
       The numeric value of the first 4 digits of the &lt;year> element must be between 1700 and the current year (inclusive).
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value '<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value '<value-of select="."/>'.
     </assert>
     
     <assert test="not(./@iso-8601-date) or substring(normalize-space(./@iso-8601-date),1,4) = $YYYY"
@@ -243,9 +243,9 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-7-5">[err-elem-cit-periodical-7-5]
       The numeric value of the first 4 digits of the @iso-8601-date attribute must match the first 4 digits on the 
       &lt;year> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
-      the value '<xsl:value-of select="."/>' and the attribute contains the value 
-      '<xsl:value-of select="./@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as the element contains
+      the value '<value-of select="."/>' and the attribute contains the value 
+      '<value-of select="./@iso-8601-date"/>'.
     </assert>
     
     <assert test="not(concat($YYYY, 'a')=.) or (concat($YYYY, 'a')=. and 
@@ -257,7 +257,7 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-7-6">[err-elem-cit-periodical-7-6]
       If the &lt;year> element contains the letter 'a' after the digits, there must be another reference with 
       the same first author surname with a letter "b" after the year. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
     
     <assert test="not(starts-with(.,$YYYY) and matches(normalize-space(.),('\d{4}[b-z]'))) or
       (some $y in //element-citation/descendant::year 
@@ -269,16 +269,16 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-7-7">[err-elem-cit-periodical-7-7]
       If the &lt;year> element contains any letter other than 'a' after the digits, there must be another 
       reference with the same first author surname with the preceding letter after the year. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
     
     <report test=". = preceding::year and 
       ancestor::element-citation/person-group[1]/name[1]/surname = preceding::year/ancestor::element-citation/person-group[1]/name[1]/surname"
       role="error" 
       id="err-elem-cit-periodical-7-8">[err-elem-cit-periodical-7-8]
       Letter suffixes must be unique for the combination of year and first author surname. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
-      contains the &lt;year> '<xsl:value-of select="."/>' more than once for the same first author surname
-      '<xsl:value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement as it 
+      contains the &lt;year> '<value-of select="."/>' more than once for the same first author surname
+      '<value-of select="ancestor::element-citation/person-group[1]/name[1]/surname"/>'.</report>
 
   </rule>
   
@@ -289,7 +289,7 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-8-2">[err-elem-cit-periodical-8-2]
       An &lt;article-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
 
@@ -299,7 +299,7 @@ with the attribute person-group-type set to 'author'. Reference
     id="err-elem-cit-periodical-10-1-2">[err-elem-cit-periodical-10-1-2]
     A  &lt;volume> element within a &lt;element-citation> of type 'periodical' must contain 
     at least one character and may not contain child elements.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters and/or
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters and/or
     child elements.</assert>
   </rule>
   
@@ -310,8 +310,8 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-11-5">[err-elem-cit-periodical-11-4]
       If the content of &lt;fpage> begins with a letter, then the content of  &lt;lpage> must begin with 
       the same letter. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has &lt;fpage>='<xsl:value-of select="."/>'
-      and &lt;lpage>='<xsl:value-of select="../lpage"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has &lt;fpage>='<value-of select="."/>'
+      and &lt;lpage>='<value-of select="../lpage"/>'.</assert>
     
   </rule>
   
@@ -322,16 +322,16 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-14-2">[err-elem-cit-periodical-14-2]
       The &lt;string-date> element must include one of each of &lt;month> and &lt;year> 
       elements.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      <xsl:value-of select="count(month)"/> &lt;month> elements and <xsl:value-of select="count(year)"/> &lt;year> elements.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      <value-of select="count(month)"/> &lt;month> elements and <value-of select="count(year)"/> &lt;year> elements.
     </assert>
     
     <assert test="count(day) le 1"
       role="error" 
       id="err-elem-cit-periodical-14-3">[err-elem-cit-periodical-14-3]
       The &lt;string-date> element may include one &lt;day> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      <xsl:value-of select="count(day)"/> &lt;day> elements.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      <value-of select="count(day)"/> &lt;day> elements.
     </assert> 
     
     <assert test="(name(child::node()[1])='month' and replace(child::node()[2],'\s+',' ')=' ' and 
@@ -340,7 +340,7 @@ with the attribute person-group-type set to 'author'. Reference
       role="error" 
       id="err-elem-cit-periodical-14-8">[err-elem-cit-periodical-14-8]
       The format of the element content must match &lt;month>, space, &lt;day>, comma, &lt;year>, or &lt;month>, comma, &lt;year>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="."/>.</assert>    
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>    
      
   </rule>
   
@@ -350,8 +350,8 @@ with the attribute person-group-type set to 'author'. Reference
       role="error" 
       id="err-elem-cit-periodical-14-4">[err-elem-cit-periodical-14-4]
       The content of &lt;month> must be the month, written out, with correct capitalization.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value  &lt;month>='<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value  &lt;month>='<value-of select="."/>'.
     </assert>
     
     <assert test=".=format-date(xs:date(../year/@iso-8601-date), '[MNn]')"
@@ -359,8 +359,8 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-14-5">[err-elem-cit-periodical-14-5]
       The content of &lt;month> must match the content of the month section of @iso-8601-date on the 
       sibling year element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value &lt;month>='<xsl:value-of select="."/>' but &lt;year>/@iso-8601-date='<xsl:value-of select="../year/@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value &lt;month>='<value-of select="."/>' but &lt;year>/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
     </assert>
 
   </rule>
@@ -371,8 +371,8 @@ with the attribute person-group-type set to 'author'. Reference
       role="error" 
       id="err-elem-cit-periodical-14-6">[err-elem-cit-periodical-14-6]
       The content of &lt;day>, if present, must be the day, in digits, with no zeroes.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value  &lt;day>='<xsl:value-of select="."/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value  &lt;day>='<value-of select="."/>'.
     </assert>
     
     <assert test=".=format-date(xs:date(../year/@iso-8601-date), '[D]')"
@@ -380,8 +380,8 @@ with the attribute person-group-type set to 'author'. Reference
       id="err-elem-cit-periodical-14-7">[err-elem-cit-periodical-14-7]
       The content of &lt;day>, if present, must match the content of the day section of @iso-8601-date on the 
       sibling year element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
-      the value &lt;day>='<xsl:value-of select="."/>' but &lt;year>/@iso-8601-date='<xsl:value-of select="../year/@iso-8601-date"/>'.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement as it contains
+      the value &lt;day>='<value-of select="."/>' but &lt;year>/@iso-8601-date='<value-of select="../year/@iso-8601-date"/>'.
     </assert>
     
   </rule>

--- a/element-citation-preprint.sch
+++ b/element-citation-preprint.sch
@@ -56,7 +56,6 @@
 <pattern
    id="element-citation-preprint-tests"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <title>element-citation publication-type="preprint" Tests</title>

--- a/element-citation-preprint.sch
+++ b/element-citation-preprint.sch
@@ -67,8 +67,8 @@
       role="error" 
       id="err-elem-cit-preprint-2-1">[err-elem-cit-preprint-2-1]
       There must be one and only one person-group. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has
+      <value-of select="count(person-group)"/> &lt;person-group> 
       elements.</assert>
 
       <assert test="count(article-title)=1"
@@ -76,35 +76,35 @@
         id="err-elem-cit-preprint-8-1">[err-elem-cit-preprint-8-1]
         Each  &lt;element-citation> of type 'preprint' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(source) = 1"
       role="error" 
       id="err-elem-cit-preprint-9-1">[err-elem-cit-preprint-9-1]
       Each  &lt;element-citation> of type 'preprint' must contain one and only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(pub-id) le 1"
       role="error" 
       id="err-elem-cit-preprint-10-1">[err-elem-cit-preprint-10-1]
       One &lt;pub-id> element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/> &lt;pub-id> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/> &lt;pub-id> elements.</assert>
     
     <assert test="count(pub-id)=1 or count(ext-link)=1"
       role="error" 
       id="err-elem-cit-preprint-10-3">[err-elem-cit-preprint-10-3]
       Either one &lt;pub-id> or one &lt;ext-link> element is required in a preprint reference.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/> &lt;pub-id> elements
-      and <xsl:value-of select="count(ext-link)"/> &lt;ext-link> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/> &lt;pub-id> elements
+      and <value-of select="count(ext-link)"/> &lt;ext-link> elements.</assert>
 
     <assert test="count(*) = count(person-group| article-title| source| year| pub-id| ext-link)"
       role="error" 
       id="err-elem-cit-preprint-13">[err-elem-cit-preprint-13]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="preprint" are:
       &lt;person-group>, &lt;article-title>, &lt;source>, &lt;year>, &lt;pub-id>, and &lt;ext-link>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -114,7 +114,7 @@
       role="error" 
       id="err-elem-cit-preprint-2-2">[err-elem-cit-preprint-2-2]
       The &lt;person-group> element must contain @person-group-type='author'. The &lt;person-group> element in 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains @person-group-type='<xsl:value-of select="@person-group-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' contains @person-group-type='<value-of select="@person-group-type"/>'.</assert>
     
   </rule>
   
@@ -124,8 +124,8 @@
       role="error" 
       id="err-elem-cit-preprint-10-2">[err-elem-cit-preprint-10-2]
       If present, the &lt;pub-id> element must contain @pub-id-type='doi'.
-      The &lt;pub-id> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>'
-      contains @pub-id-type='<xsl:value-of select="@pub-id-type"/>'.</assert>
+      The &lt;pub-id> element in Reference '<value-of select="ancestor::ref/@id"/>'
+      contains @pub-id-type='<value-of select="@pub-id-type"/>'.</assert>
     
   </rule>
 
@@ -135,21 +135,21 @@
       role="error" 
       id="err-elem-cit-preprint-11-1">[err-elem-cit-preprint-11-1]
       Each &lt;ext-link> element must contain @xlink:href.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-preprint-11-2">[err-elem-cit-preprint-11-2]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-preprint-11-3">[err-elem-cit-preprint-11-3]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
   
@@ -159,14 +159,14 @@
     id="err-elem-cit-preprint-8-2-1">[err-elem-cit-preprint-8-2-1]
     A &lt;article-title> element within a &lt;element-citation> of type 'preprint' must contain 
     at least two characters.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
   
   <assert test="count(*)=count(italic | sub | sup)"
     role="error" 
     id="err-elem-cit-preprint-8-2-2">[err-elem-cit-preprint-8-2-2]
     A &lt;article-title> element within a &lt;element-citation> of type 'preprint' may only contain the child 
     elements&lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='preprint']/source" id="elem-citation-preprint-source"> 
@@ -175,14 +175,14 @@
       id="err-elem-cit-preprint-9-2-1">[err-elem-cit-preprint-9-2-1]
       A &lt;source> element within a &lt;element-citation> of type 'preprint' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(*)=count(italic | sub | sup)"
       role="error" 
       id="err-elem-cit-preprint-9-2-2">[err-elem-cit-preprint-9-2-2]
       A &lt;source> element within a &lt;element-citation> of type 'preprint' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
   </rule>
   

--- a/element-citation-report-pre-edit.sch
+++ b/element-citation-report-pre-edit.sch
@@ -30,8 +30,7 @@
 
 <pattern
    id="element-citation-report-pre-edit-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="report" Pre-edit Tests</title>
 

--- a/element-citation-report-pre-edit.sch
+++ b/element-citation-report-pre-edit.sch
@@ -42,7 +42,7 @@
       role="warning" 
       id="warning-elem-cit-report-10">[warning-elem-cit-report-10]
       There should be a &lt;publisher-loc> element within a &lt;element-citation> of type 'report'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not have one &lt;publisher-loc> element.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not have one &lt;publisher-loc> element.</assert>
 
   </rule>
 

--- a/element-citation-report.sch
+++ b/element-citation-report.sch
@@ -68,22 +68,22 @@
       role="error" 
       id="err-elem-cit-report-2-1">[err-elem-cit-report-2-1]
       One and only one person-group element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="count(source)=1"
       role="error" 
       id="err-elem-cit-report-9-1">[err-elem-report-report-9-1]
       Each  &lt;element-citation> of type 'report' must contain one and
       only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</assert>
     
     <assert test="count(publisher-name)=1"
       role="error" 
       id="err-elem-cit-report-11-1">[err-elem-cit-report-11-1]
       &lt;publisher-name> is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(publisher-name)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(publisher-name)"/>
       &lt;publisher-name> elements.</assert>
     
     <report test="some $p in document($publisher-locations)/locations/location/text()
@@ -91,7 +91,7 @@
       role="warning" 
       id="warning-elem-cit-report-11-3">[warning-elem-cit-report-11-3]
       The content of &lt;publisher-name> may not end with a publisher location. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains the string <xsl:value-of select="publisher-name"/>,
+      Reference '<value-of select="ancestor::ref/@id"/>' contains the string <value-of select="publisher-name"/>,
       which ends with a publisher location.</report>
     
     <assert test="count(*) = count(person-group| year| source| publisher-loc|publisher-name| ext-link| pub-id)"
@@ -99,7 +99,7 @@
       id="err-elem-cit-report-15">[err-elem-cit-report-15]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="report" are:
       &lt;person-group>, &lt;year>, &lt;source>, &lt;publisher-loc>, &lt;publisher-name>, &lt;ext-link>, and &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -108,8 +108,8 @@
       role="error" 
       id="err-elem-cit-report-2-2">[err-elem-cit-report-2-2]
       Each &lt;person-group> must have a @person-group-type attribute of type 'author'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
-      element with @person-group-type attribute '<xsl:value-of select="@person-group-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
+      element with @person-group-type attribute '<value-of select="@person-group-type"/>'.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='report']/source" id="elem-citation-report-source">
@@ -118,14 +118,14 @@
     id="err-elem-cit-report-9-2-1">[err-elem-cit-report-9-2-1]
     A  &lt;source> element within a &lt;element-citation> of type 'report' must contain 
     at least two characters.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
   
   <assert test="count(*)=count(italic | sub | sup)"
     role="error" 
     id="err-elem-cit-report-9-2-2">[err-elem-cit-report-9-2-2]
     A  &lt;source> element within a &lt;element-citation> of type 'report' may only contain the child 
     elements: &lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has child elements that are not allowed.</assert>
     
   </rule>
   
@@ -135,7 +135,7 @@
       role="error" 
       id="err-elem-cit-report-11-2">[err-elem-cit-report-11-2]
       No elements are allowed inside &lt;publisher-name>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;publisher-name> element.</assert>
     
   </rule>
@@ -146,8 +146,8 @@
       role="error" 
       id="err-elem-cit-report-12-2">[err-elem-cit-report-12-2]
       The only allowed pub-id types are 'doi' and 'isbn'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a pub-id type of 
-      '<xsl:value-of select="@pub-id-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a pub-id type of 
+      '<value-of select="@pub-id-type"/>'.</assert>
     
   </rule>
   
@@ -156,22 +156,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-report-14-1">[err-elem-cit-report-14-1]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-report-14-2">[err-elem-cit-report-14-2]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-report-14-3">[err-elem-cit-report-14-3]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
 

--- a/element-citation-report.sch
+++ b/element-citation-report.sch
@@ -56,8 +56,7 @@
 
 <pattern
    id="element-citation-report-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="report" Tests</title>
              

--- a/element-citation-software.sch
+++ b/element-citation-software.sch
@@ -59,26 +59,26 @@
       role="error" id="err-elem-cit-software-2-1">[err-elem-cit-software-2-1] Each
       &lt;element-citation> of type 'software' must contain one &lt;person-group> element (either
       author or curator) or one &lt;person-group> with attribute person-group-type = author and one
-      &lt;person-group> with attribute person-group-type = curator. Reference '<xsl:value-of
-        select="ancestor::ref/@id"/>' has <xsl:value-of select="count(person-group)"/>
+      &lt;person-group> with attribute person-group-type = curator. Reference '<value-of
+        select="ancestor::ref/@id"/>' has <value-of select="count(person-group)"/>
       &lt;person-group> elements.</assert>
 
     <assert test="person-group[@person-group-type = ('author', 'curator')]" role="error"
       id="err-elem-cit-software-2-2">[err-elem-cit-software-2-2] Each &lt;element-citation> of type
       'software' must contain one &lt;person-group> with the attribute person-group-type set to
-      'author'or 'curator'. Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a
-      &lt;person-group> type of '<xsl:value-of select="person-group/@person-group-type"/>'.</assert>
+      'author'or 'curator'. Reference '<value-of select="ancestor::ref/@id"/>' has a
+      &lt;person-group> type of '<value-of select="person-group/@person-group-type"/>'.</assert>
 
     <report test="count(data-title) > 1" role="error" id="err-elem-cit-software-10-1"
       >[err-elem-cit-software-10-1] Each &lt;element-citation> of type 'software' may contain one
-      and only one &lt;data-title> element. Reference '<xsl:value-of select="ancestor::ref/@id"/>'
-      has <xsl:value-of select="count(data-title)"/> &lt;data-title> elements.</report>
+      and only one &lt;data-title> element. Reference '<value-of select="ancestor::ref/@id"/>'
+      has <value-of select="count(data-title)"/> &lt;data-title> elements.</report>
 
     <assert test="count(*) = count(person-group | year | data-title | source | version | publisher-name | publisher-loc | ext-link)"
       role="error" id="err-elem-cit-software-16">[err-elem-cit-software-16] The only tags that are
       allowed as children of &lt;element-citation> with the publication-type="software" are:
       &lt;person-group>, &lt;year>, &lt;data-title>, &lt;source>, &lt;version>, &lt;publisher-name>,
-      &lt;publisher-loc>, and &lt;ext-link> Reference '<xsl:value-of select="ancestor::ref/@id"/>'
+      &lt;publisher-loc>, and &lt;ext-link> Reference '<value-of select="ancestor::ref/@id"/>'
       has other elements.</assert>
 
   </rule>
@@ -89,7 +89,7 @@
     <assert test="count(*) = count(sub | sup | italic)" role="error" id="err-elem-cit-software-10-2"
       >[err-elem-cit-software-10-2] An &lt;data-title> element in a reference may contain characters
       and &lt;italic>, &lt;sub>, and &lt;sup>. No other elements are allowed. Reference
-        '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+        '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
 
   </rule>
 
@@ -98,20 +98,20 @@
 
     <assert test="@xlink:href" role="error" id="err-elem-cit-software-15-1"
       >[err-elem-cit-software-15-1] Each &lt;ext-link> element must contain @xlink:href. The
-      &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' does
+      &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' does
       not.</assert>
 
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" id="err-elem-cit-software-15-2">[err-elem-cit-software-15-2] The value of
       @xlink:href must start with either "http://" or "https://". The &lt;ext-link> element in
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' is '<xsl:value-of select="@xlink:href"
+      Reference '<value-of select="ancestor::ref/@id"/>' is '<value-of select="@xlink:href"
       />', which does not.</assert>
 
     <assert test="normalize-space(@xlink:href) = normalize-space(.)" role="error"
       id="err-elem-cit-software-15-3">[err-elem-cit-software-15-3] The value of @xlink:href must be
       the same as the element content of &lt;ext-link>. The &lt;ext-link> element in Reference
-        '<xsl:value-of select="ancestor::ref/@id"/>' has @xlink:href='<xsl:value-of
-        select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+        '<value-of select="ancestor::ref/@id"/>' has @xlink:href='<value-of
+        select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
 
   </rule>
 

--- a/element-citation-thesis.sch
+++ b/element-citation-thesis.sch
@@ -66,8 +66,7 @@
 
 <pattern
    id="element-citation-thesis-tests"
-   xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+   xmlns="http://purl.oclc.org/dsdl/schematron">
 
 <title>element-citation publication-type="thesis" Tests</title>
              

--- a/element-citation-thesis.sch
+++ b/element-citation-thesis.sch
@@ -77,43 +77,43 @@
       role="error" 
       id="err-elem-cit-thesis-2-1">[err-elem-cit-thesis-2-1]
       One and only one person-group element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(person-group)"/> &lt;person-group> elements.</assert>
     
     <assert test="count(collab)=0"
       role="error" 
       id="err-elem-cit-thesis-3">[err-elem-cit-thesis-3]
       No &lt;collab> elements are allowed in thesis citations.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(collab)"/> &lt;collab> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(collab)"/> &lt;collab> elements.</assert>
     
     <assert test="count(etal)=0"
       role="error" 
       id="err-elem-cit-thesis-6">[err-elem-cit-thesis-6]
       No &lt;etal> elements are allowed in thesis citations.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(etal)"/> &lt;etal> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(etal)"/> &lt;etal> elements.</assert>
     
     <assert test="count(article-title)=1"
       role="error" 
       id="err-elem-cit-thesis-8-1">[err-elem-cit-thesis-8-1]
       Each  &lt;element-citation> of type 'thesis' must contain one and
       only one &lt;article-title> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <assert test="count(publisher-name)=1"
       role="error" 
       id="err-elem-cit-thesis-9-1">[err-elem-cit-thesis-9-1]
       &lt;publisher-name> is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(publisher-name)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(publisher-name)"/>
       &lt;publisher-name> elements.</assert>
             
     <assert test="count(pub-id) le 1"
       role="error" 
       id="err-elem-cit-thesis-11-1">[err-elem-cit-thesis-11-1]
       A maximum of one &lt;pub-id> element is allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(pub-id)"/>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(pub-id)"/>
       &lt;pub-id> elements.</assert>
     
     <assert test="count(*) = count(person-group | article-title | year| source | publisher-loc | publisher-name | ext-link | pub-id)"
@@ -122,7 +122,7 @@
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="thesis" are:
       &lt;person-group>, &lt;year>, &lt;article-title>, &lt;source>, &lt;publisher-loc>, &lt;publisher-name>, 
       &lt;ext-link>, and &lt;pub-id>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -132,15 +132,15 @@
       role="error" 
       id="err-elem-cit-thesis-2-2">[err-elem-cit-thesis-2-2]
       Each &lt;person-group> must have a @person-group-type attribute of type 'author'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
-      element with @person-group-type attribute '<xsl:value-of select="@person-group-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> 
+      element with @person-group-type attribute '<value-of select="@person-group-type"/>'.</assert>
     
     <assert test="count(name)=1"
       role="error" 
       id="err-elem-cit-thesis-2-3">[err-elem-cit-thesis-2-3]
       Each thesis citation must have one and only one author.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a thesis citation 
-      with <xsl:value-of select="count(name)"/> authors.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a thesis citation 
+      with <value-of select="count(name)"/> authors.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='thesis']/article-title" id="elem-citation-thesis-article-title">
@@ -150,7 +150,7 @@
       id="err-elem-cit-thesis-8-2">[err-elem-cit-thesis-8-2]
       An &lt;article-title> element in a reference may contain characters and &lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' does not meet this requirement.</assert>
     
   </rule>
   
@@ -160,7 +160,7 @@
       role="error" 
       id="err-elem-cit-thesis-9-2">[err-elem-cit-thesis-9-2]
       No elements are allowed inside &lt;publisher-name>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;publisher-name> element.</assert>
     
   </rule>
@@ -171,7 +171,7 @@
       role="error" 
       id="err-elem-cit-thesis-10-2">[err-elem-cit-thesis-10-2]
       No elements are allowed inside &lt;publisher-loc>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has child elements within the
+      Reference '<value-of select="ancestor::ref/@id"/>' has child elements within the
       &lt;publisher-loc> element.</assert>
     
   </rule>
@@ -182,8 +182,8 @@
       role="error" 
       id="err-elem-cit-thesis-11-2">[err-elem-cit-thesis-11-2]
       The only allowed pub-id type is 'doi'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has a pub-id type of 
-      '<xsl:value-of select="@pub-id-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has a pub-id type of 
+      '<value-of select="@pub-id-type"/>'.</assert>
     
   </rule>
   
@@ -192,22 +192,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-thesis-12-1">[err-elem-cit-thesis-12-1]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-thesis-12-2">[err-elem-cit-thesis-12-2]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-thesis-12-3">[err-elem-cit-thesis-12-3]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
 

--- a/element-citation-web.sch
+++ b/element-citation-web.sch
@@ -57,7 +57,6 @@
 <pattern
    id="element-citation-web-tests"
    xmlns="http://purl.oclc.org/dsdl/schematron"
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
    xmlns:xlink="http://www.w3.org/1999/xlink">
 
 <title>element-citation publication-type="web" Tests</title>

--- a/element-citation-web.sch
+++ b/element-citation-web.sch
@@ -68,8 +68,8 @@
       role="error" 
       id="err-elem-cit-web-2-1">[err-elem-cit-web-2-1]
       There must be one and only one person-group. 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has
-      <xsl:value-of select="count(person-group)"/> &lt;person-group> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has
+      <value-of select="count(person-group)"/> &lt;person-group> 
       elements.</assert>
 
       <assert test="count(article-title)=1"
@@ -77,28 +77,28 @@
         id="err-elem-cit-web-8-1">[err-elem-cit-web-8-1]
         Each  &lt;element-citation> of type 'web' must contain one and
         only one &lt;article-title> element.
-        Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-        <xsl:value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
+        Reference '<value-of select="ancestor::ref/@id"/>' has 
+        <value-of select="count(article-title)"/> &lt;article-title> elements.</assert>
     
     <report test="count(source) > 1"
       role="error" 
       id="err-elem-cit-web-9-1">[err-elem-cit-web-9-1]
       Each  &lt;element-citation> of type 'web' may contain one and only one &lt;source> element.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has 
-      <xsl:value-of select="count(source)"/> &lt;source> elements.</report>
+      Reference '<value-of select="ancestor::ref/@id"/>' has 
+      <value-of select="count(source)"/> &lt;source> elements.</report>
     
     <assert test="count(ext-link)=1"
       role="error" 
       id="err-elem-cit-web-10-1">[err-elem-cit-web-10-1]
       One and only one &lt;ext-link> element is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(ext-link)"/> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(ext-link)"/> 
       &lt;ext-link> elements.</assert>
     
     <assert test="count(date-in-citation)=1"
       role="error" 
       id="err-elem-cit-web-11-1">[err-elem-cit-web-11-1]
       One and only one &lt;date-in-citation> element is required.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="count(date-in-citation)"/> 
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="count(date-in-citation)"/> 
       &lt;date-in-citation> elements.</assert>
 
     <assert test="count(*) = count(person-group|article-title|source|year|ext-link|date-in-citation)"
@@ -106,7 +106,7 @@
       id="err-elem-cit-web-12">[err-elem-cit-web-12]
       The only tags that are allowed as children of &lt;element-citation> with the publication-type="web" are:
       &lt;person-group>, &lt;article-title>, &lt;source>, &lt;year>, &lt;ext-link> and &lt;date-in-citation>.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has other elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has other elements.</assert>
 
   </rule>
   
@@ -116,7 +116,7 @@
       role="error" 
       id="err-elem-cit-web-2-2">[err-elem-cit-web-2-2]
       The &lt;person-group> element must contain @person-group-type='author'. The &lt;person-group> element in 
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' contains @person-group-type='<xsl:value-of select="@person-group-type"/>'.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' contains @person-group-type='<value-of select="@person-group-type"/>'.</assert>
     
   </rule>
 
@@ -125,22 +125,22 @@
     <assert test="@xlink:href"
       role="error" 
       id="err-elem-cit-web-10-2">[err-elem-cit-web-10-2]
-      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
+      Each &lt;ext-link> element must contain @xlink:href. The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
       does not.</assert>
     
     <assert test="starts-with(@xlink:href, 'http://') or starts-with(@xlink:href, 'https://')"
       role="error" 
       id="err-elem-cit-web-10-3">[err-elem-cit-web-10-3]
       The value of @xlink:href must start with either "http://" or "https://". 
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      is '<xsl:value-of select="@xlink:href"/>', which does not.</assert>  
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      is '<value-of select="@xlink:href"/>', which does not.</assert>  
     
     <assert test="normalize-space(@xlink:href)=normalize-space(.)"
       role="error" 
       id="err-elem-cit-web-10-4">[err-elem-cit-web-10-4]
       The value of @xlink:href must be the same as the element content of &lt;ext-link>.
-      The &lt;ext-link> element in Reference '<xsl:value-of select="ancestor::ref/@id"/>' 
-      has @xlink:href='<xsl:value-of select="@xlink:href"/>' and content '<xsl:value-of select="."/>'.</assert>
+      The &lt;ext-link> element in Reference '<value-of select="ancestor::ref/@id"/>' 
+      has @xlink:href='<value-of select="@xlink:href"/>' and content '<value-of select="."/>'.</assert>
     
   </rule>
   
@@ -150,7 +150,7 @@
     id="err-elem-cit-web-8-2-1">[err-elem-cit-web-8-2-1]
     A  &lt;article-title> element within a &lt;element-citation> of type 'web' must contain 
     at least two characters.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
   
   <assert test="count(*)=count(italic | sub | sup)"
     role="error" 
@@ -158,7 +158,7 @@
     A  &lt;article-title> element within a &lt;element-citation> of type 'web' may only contain the child 
     elements&lt;italic>, &lt;sub>, and &lt;sup>. 
     No other elements are allowed.
-    Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+    Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
   </rule>
   
   <rule context="element-citation[@publication-type='web']/source" id="elem-citation-web-source"> 
@@ -167,7 +167,7 @@
       id="err-elem-cit-web-9-2-1">[err-elem-cit-web-9-2-1]
       A  &lt;source> element within a &lt;element-citation> of type 'web' must contain 
       at least two characters.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has too few characters.</assert>
     
     <assert test="count(*)=count(italic | sub | sup)"
       role="error" 
@@ -175,7 +175,7 @@
       A  &lt;source> element within a &lt;element-citation> of type 'web' may only contain the child 
       elements&lt;italic>, &lt;sub>, and &lt;sup>. 
       No other elements are allowed.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has disallowed child elements.</assert>
     
   </rule>
   
@@ -184,7 +184,7 @@
       role="error" 
       id="err-elem-cit-web-11-2-1">[err-elem-cit-web-11-2-1]
       The &lt;date-in-citation> element must have an @iso-8601-date attribute.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' does not.
+      Reference '<value-of select="ancestor::ref/@id"/>' does not.
     </assert>
     
     <assert test="matches(./@iso-8601-date,'^\d{4}-\d{2}-\d{2}$')"
@@ -192,7 +192,7 @@
       id="err-elem-cit-web-11-2-2">[err-elem-cit-web-11-2-2]
       The &lt;date-in-citation> element's @iso-8601-date attribute must have the format
       'YYYY-MM-DD'.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has '<xsl:value-of select="@iso-8601-date"/>',
+      Reference '<value-of select="ancestor::ref/@id"/>' has '<value-of select="@iso-8601-date"/>',
       which does not have that format.
     </assert>
 
@@ -200,16 +200,16 @@
       role="error" 
       id="err-elem-cit-web-11-3">[err-elem-cit-web-11-3]
       The format of the element content must match month, space, day, comma, year.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has <xsl:value-of select="."/>.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has <value-of select="."/>.</assert>
     
     <!-- issue 5 on the eLife lists -->
     <assert test="(string-length(@iso-8601-date) > 4) and format-date(xs:date(@iso-8601-date), '[MNn] [D], [Y]')=."
       role="error" 
       id="err-elem-cit-web-11-4">[err-elem-cit-web-11-4]
       The element content date must match the @iso-8601-date value.
-      Reference '<xsl:value-of select="ancestor::ref/@id"/>' has element content of 
-      <xsl:value-of select="."/> but an @iso-8601-date value of 
-      <xsl:value-of select="@iso-8601-date"/>.</assert>
+      Reference '<value-of select="ancestor::ref/@id"/>' has element content of 
+      <value-of select="."/> but an @iso-8601-date value of 
+      <value-of select="@iso-8601-date"/>.</assert>
     
   </rule>
   


### PR DESCRIPTION
Uses the un-namespaced version of '<value-of/>' to avoid situations where the
<value-of> tag is stripped out before the validation stage.  This occurs in
http://phax.github.io/ph-schematron/ where the SCH file is passed through
several preparation stages and the <xsl:value-of> is wrongly evaluated and
stripped out during the 3rd.

cc @nlisgo @JGilbert-eLife -- this will fix the diagnostic messages, however, makes it hard to write a test that `<xsl:value-of/>` won't be used again.  I have a WIP change in `schematron-validator` that'll try to convert any input SCH files using the namespaced version to the freestanding version.