### PR TITLE
Correction to logic in person-group rules 2-2 and 2-3

### DIFF
--- a/element-citation-book.sch
+++ b/element-citation-book.sch
@@ -91,15 +91,14 @@
   <rule context="element-citation[@publication-type='book']" id="elem-citation-book">
     <let name="publisher-locations" value="'publisher-locations.xml'"/>
 
-    <assert test="person-group[@person-group-type='author'] or person-group[@person-group-type='editor']"
+    <assert test="(count(person-group[@person-group-type='author']) + count(person-group[@person-group-type='editor'])) = count(person-group)"
       role="error" 
       id="err-elem-cit-book-2-2">[err-elem-cit-book-2-2]
       The only values allowed for @person-group-type in book references are "author" and "editor".
       Reference '<value-of select="ancestor::ref/@id"/>' has a &lt;person-group> type of 
       '<value-of select="person-group/@person-group-type"/>'.</assert> 
     
-    <assert test="count(person-group)=1 or (count(person-group/@person-group-type='author')+
-      count(person-group/@person-group-type='editor')=2)"
+    <assert test="count(person-group)=1 or (count(person-group[@person-group-type='author'])=1 and count(person-group[@person-group-type='editor'])=1)"
       role="error" 
       id="err-elem-cit-book-2-3">[err-elem-cit-book-2-3]
       In a book reference, there should be a single person-group element (either author or editor) or


### PR DESCRIPTION
Hi @nlisgo - this is a correction we need to make to the book tests. There should be no issues as we don't have any test files for the book tests at present (a gap to be closed in the future).

The change fixes the logic of two rules so they actually cover what we need them to.

Please could you merge it in and update the validator?