### PR TITLE
Update to stop rule err-elem-cit-gen-date-1-8 running on data section

### DIFF
--- a/element-citation-general.sch
+++ b/element-citation-general.sch
@@ -196,7 +196,7 @@ Reference '<value-of select="ancestor::ref/@id"/>' does not.</report>
       reference with the same first author surname (or collab) with the preceding letter after the year. 
       Reference '<value-of select="ancestor::ref/@id"/>' does not fulfill this requirement.</assert>
     
-    <report test="some $x in (preceding::year)
+    <report test="some $x in (preceding::year[ancestor::ref-list])
       satisfies (((count(ancestor::element-citation/person-group[1]/*)=1 and 
       count($x/ancestor::element-citation/person-group[1]/*)=1) and 
       ((ancestor::element-citation/person-group[1]/name[1]/surname and 


### PR DESCRIPTION
Hi @nlisgo - me again.

We have found a bug where rule err-elem-cit-gen-date-1-8 is running on the data availability section when it needs to be restricted to ref-list. Fred and I have updated the rule to fix this. It should have no effect on the tests.

Please could you merge this in and push to the validator?

Thanks!

James